### PR TITLE
fix: support RTD addons

### DIFF
--- a/deepmodeling_sphinx/banner.css
+++ b/deepmodeling_sphinx/banner.css
@@ -24,7 +24,8 @@ under MIT license
   padding-right: 0;
   padding-left: 0;
   /* pydata theme has z-index 1030; we should be the largest */
-  z-index: 2000;
+  /* RTD banner use 1750; we should be smaller than RTD */
+  z-index: 1749;
 }
 
 .header-holder .container {

--- a/deepmodeling_sphinx/inject.py
+++ b/deepmodeling_sphinx/inject.py
@@ -170,11 +170,11 @@ def enable_dark_mode(app, config):
 
 def rtd_config(app, config):
     """Set RTD configurations.
-    
+
     See https://about.readthedocs.com/blog/2024/07/addons-by-default/
     """
     config.html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
-    
+
     # Tell Jinja2 templates the build is running on Read the Docs
     if os.environ.get("READTHEDOCS", "") == "True":
         if "html_context" not in config:

--- a/deepmodeling_sphinx/inject.py
+++ b/deepmodeling_sphinx/inject.py
@@ -168,6 +168,20 @@ def enable_dark_mode(app, config):
         app.add_css_file("dark_rtd.css")
 
 
+def rtd_config(app, config):
+    """Set RTD configurations.
+    
+    See https://about.readthedocs.com/blog/2024/07/addons-by-default/
+    """
+    config.html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+    
+    # Tell Jinja2 templates the build is running on Read the Docs
+    if os.environ.get("READTHEDOCS", "") == "True":
+        if "html_context" not in config:
+            config.html_context = {}
+        config.html_context["READTHEDOCS"] = True
+
+
 def setup(app: Sphinx) -> Dict[str, Any]:
     # enable deepmodeling sidebar and icp
     # if the repo is outside the deepmodeling, disable it
@@ -181,5 +195,6 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect("build-finished", minify_css_files)
     # dark mode for rtd theme
     app.connect("config-inited", enable_dark_mode)
+    app.connect("config-inited", rtd_config)
 
     return {"parallel_read_safe": True}

--- a/deepmodeling_sphinx/inject.py
+++ b/deepmodeling_sphinx/inject.py
@@ -121,7 +121,7 @@ def minify_html_files(app, pagename, templatename, context, doctree):
         def render(self, template, render_context):
             content = old_render(template, render_context)
             try:
-                return minify_html.minify(content, minify_js=True, minify_css=True)
+                return minify_html.minify(content, minify_js=True, minify_css=True, keep_html_and_head_opening_tags=True)
             except SyntaxError:
                 return content
 
@@ -190,7 +190,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect("builder-inited", copy_custom_files)
     app.connect("html-page-context", insert_sidebar)
     app.connect("html-page-context", insert_icp)
-    # app.connect("html-page-context", minify_html_files)
+    app.connect("html-page-context", minify_html_files)
     app.connect("build-finished", minify_js_files)
     app.connect("build-finished", minify_css_files)
     # dark mode for rtd theme

--- a/deepmodeling_sphinx/inject.py
+++ b/deepmodeling_sphinx/inject.py
@@ -190,7 +190,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect("builder-inited", copy_custom_files)
     app.connect("html-page-context", insert_sidebar)
     app.connect("html-page-context", insert_icp)
-    app.connect("html-page-context", minify_html_files)
+    # app.connect("html-page-context", minify_html_files)
     app.connect("build-finished", minify_js_files)
     app.connect("build-finished", minify_css_files)
     # dark mode for rtd theme

--- a/deepmodeling_sphinx/inject.py
+++ b/deepmodeling_sphinx/inject.py
@@ -121,7 +121,12 @@ def minify_html_files(app, pagename, templatename, context, doctree):
         def render(self, template, render_context):
             content = old_render(template, render_context)
             try:
-                return minify_html.minify(content, minify_js=True, minify_css=True, keep_html_and_head_opening_tags=True)
+                return minify_html.minify(
+                    content,
+                    minify_js=True,
+                    minify_css=True,
+                    keep_html_and_head_opening_tags=True,
+                )
             except SyntaxError:
                 return content
 

--- a/deepmodeling_sphinx/inject.py
+++ b/deepmodeling_sphinx/inject.py
@@ -126,6 +126,7 @@ def minify_html_files(app, pagename, templatename, context, doctree):
                     minify_js=True,
                     minify_css=True,
                     keep_html_and_head_opening_tags=True,
+                    keep_closing_tags=True,
                 )
             except SyntaxError:
                 return content


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/07/addons-by-default/

Changes:
1. Set configurations suggested by https://about.readthedocs.com/blog/2024/07/addons-by-default/;
2. Keep `</head>` when minifying HTML files as RTD replaces it;
3. Set z-index of our banner to 1749, as the new RTD banner uses 1750.